### PR TITLE
fix: eliminate black-square flash on startup, start cleanly in tray

### DIFF
--- a/MoneyShot/App.xaml
+++ b/MoneyShot/App.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:MoneyShot"
-             StartupUri="MainWindow.xaml">
+             ShutdownMode="OnExplicitShutdown">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/MoneyShot/App.xaml.cs
+++ b/MoneyShot/App.xaml.cs
@@ -32,6 +32,14 @@ public partial class App : Application
         }
 
         base.OnStartup(e);
+
+        // StartupUri is intentionally not used. It calls Show() during startup, which paints an
+        // unrendered (black) frame before the Loaded handler can hide it when StartInTray is set.
+        // Instead we create the window here and let InitializeApplication decide whether to show
+        // it or just realize its handle for hotkeys — see MainWindow.InitializeApplication.
+        var mainWindow = new MainWindow();
+        MainWindow = mainWindow;
+        mainWindow.InitializeApplication();
     }
 
     protected override void OnExit(ExitEventArgs e)

--- a/MoneyShot/MainWindow.xaml.cs
+++ b/MoneyShot/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Forms;
 using System.Windows.Input;
+using System.Windows.Interop;
 using System.Windows.Media;
 using MoneyShot.Services;
 using MoneyShot.Views;
@@ -37,27 +38,40 @@ public partial class MainWindow : Window
         _historyService = new HistoryService();
 
         SetupSystemTray();
-        Loaded += MainWindow_Loaded;
     }
 
-    private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
+    /// <summary>
+    /// Performs post-construction startup: realizes the native handle, binds global hotkeys, and
+    /// shows the window only when the user hasn't opted to start in the tray. Called once from
+    /// <see cref="App.OnStartup"/>. When <see cref="Models.AppSettings.StartInTray"/> is set the
+    /// window is never shown — <see cref="WindowInteropHelper.EnsureHandle"/> creates the HWND that
+    /// hotkey registration needs without painting anything, which avoids the black-frame flash that
+    /// Show()-then-Hide() produced.
+    /// </summary>
+    public void InitializeApplication()
     {
         try
         {
+            var settings = _settingsService.LoadSettings();
+
+            if (settings.StartInTray)
+            {
+                // Realize the Win32 handle without making the window visible.
+                new WindowInteropHelper(this).EnsureHandle();
+            }
+            else
+            {
+                ShowMainWindow();
+            }
+
+            // The HWND now exists (via EnsureHandle or Show), so global hotkeys can bind to it.
             _hotKeyService.Initialize(this);
             RegisterHotKeys();
             PopulateMonitorButtons();
-            
-            // Check if app should start in tray
-            var settings = _settingsService.LoadSettings();
-            if (settings.StartInTray)
-            {
-                Hide();
-            }
 
             if (settings.CheckForUpdatesOnStartup)
             {
-                await CheckForUpdatesOnStartupAsync();
+                _ = CheckForUpdatesOnStartupAsync();
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## What

Fixes the black square that briefly appears on app startup and ensures the app starts minimized to the system tray with no visible window.

## Why

`App.xaml` used `StartupUri="MainWindow.xaml"`, which makes WPF **Show()** the window during startup. The `StartInTray` check (and `Hide()`) only ran afterward in the `Loaded` handler — which fires *after* the window is shown and composed. With `WindowStyle="None"` + `WindowChrome`, the brief frame before the WPF content painted appeared as a **black square** that then vanished. It was an unavoidable Show-then-Hide flash.

## How

- **`App.xaml`** — removed `StartupUri` (which forces `Show()`); set `ShutdownMode="OnExplicitShutdown"`, the correct mode for a tray app whose main window may never be shown (otherwise WPF could quit when a transient dialog like the editor closes).
- **`App.xaml.cs`** — `OnStartup` now creates `MainWindow` explicitly and calls `InitializeApplication()` instead of relying on `StartupUri`.
- **`MainWindow.xaml.cs`** — replaced the `Loaded` handler with `InitializeApplication()`. When `StartInTray` is set it calls `WindowInteropHelper.EnsureHandle()` to realize the native HWND (needed for global hotkey registration) **without** painting the window; otherwise it shows the window normally. Hotkeys bind after the handle exists in both paths.

## Testing

- `dotnet build` clean (0 warnings / 0 errors).
- `dotnet test` — 109/109 service tests pass.
- Launched the built exe: process stays alive with `MainWindowHandle: 0`, and an `EnumWindows` sweep confirmed **zero visible top-level windows** for the process — starts silently in the tray, no black-square flash.

## Reviewer notes

- No automated UI coverage exists (per `DEVELOPER.md`). Manual check worth doing on Windows: launch, then tray icon → "Show Window", and confirm a capture hotkey (Print Screen) still fires.
- `WindowStartupLocation="CenterScreen"` is computed at handle-creation time inside `CreateSourceWindow`, so it is still honored even when the handle is realized early via `EnsureHandle()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)